### PR TITLE
Update DesktopLauncher.java

### DIFF
--- a/desktop/src/com/rolandoislas/drcsimclient/desktop/DesktopLauncher.java
+++ b/desktop/src/com/rolandoislas/drcsimclient/desktop/DesktopLauncher.java
@@ -15,8 +15,8 @@ import com.rolandoislas.drcsimclient.desktop.audio.Audio;
 public class DesktopLauncher {
 	public static void main (String[] arg) {
 		LwjglApplicationConfiguration config = new LwjglApplicationConfiguration();
-		config.width = 1280;
-		config.height = 720;
+		config.width = 854;
+		config.height = 480;
 		config.title = Constants.NAME;
 		config.backgroundFPS = 60;
 		if (System.getProperties().getProperty("os.name").toLowerCase().contains("mac")) {

--- a/desktop/src/com/rolandoislas/drcsimclient/desktop/DesktopLauncher.java
+++ b/desktop/src/com/rolandoislas/drcsimclient/desktop/DesktopLauncher.java
@@ -18,7 +18,7 @@ public class DesktopLauncher {
 		config.width = 1280;
 		config.height = 720;
 		config.title = Constants.NAME;
-		config.backgroundFPS = 30;
+		config.backgroundFPS = 60;
 		if (System.getProperties().getProperty("os.name").toLowerCase().contains("mac")) {
 			config.addIcon("image/icon-512.png", Files.FileType.Internal);
 			config.addIcon("image/icon-256.png", Files.FileType.Internal);


### PR DESCRIPTION
Update background FPS Value to 60 to avoid unnecessary Framedrops when Window is not in Focus.